### PR TITLE
Adding async and layout rendering of Keys

### DIFF
--- a/NLog.Extensions.AzureTableStorage.Tests/AzureTableStorageKeysTests.cs
+++ b/NLog.Extensions.AzureTableStorage.Tests/AzureTableStorageKeysTests.cs
@@ -209,12 +209,22 @@ namespace NLog.Extensions.AzureTableStorage.Tests
             return CloudConfigurationManager.GetSetting("ConnectionString");
         }
 
-        private async Task<List<LogEntity>> GetLogEntities()
+        private async Task<List<LogEntity>> GetLogEntities(int retryCount = 2)
         {
-            await Task.Delay(250);
-            var query = new TableQuery<LogEntity>();
-            var entities = _cloudTable.ExecuteQuery(query);
-            return entities.ToList();
+            var entities = new List<LogEntity>();
+
+            for (var i = 0; i < retryCount; i++)
+            {
+                await Task.Delay(250);
+                var query = new TableQuery<LogEntity>();
+                entities = new List<LogEntity>(_cloudTable.ExecuteQuery(query));
+                if (entities.Count != 0)
+                {
+                    break;
+                }
+            }
+
+            return entities;
         }
 
         private CloudStorageAccount GetStorageAccount()

--- a/NLog.Extensions.AzureTableStorage.Tests/AzureTableStoragePerformanceTests.cs
+++ b/NLog.Extensions.AzureTableStorage.Tests/AzureTableStoragePerformanceTests.cs
@@ -82,16 +82,22 @@ namespace NLog.Extensions.AzureTableStorage.Tests
         private async Task<List<LogEntity>> GetLogEntities(int expectedCount)
         {
             var entities = new List<LogEntity>();
+            var previousCount = 0;
 
-            for (var i = 0; i < 5; i++)
+            while(true)
             {
                 await Task.Delay(2500);
                 var query = new TableQuery<LogEntity>();
                 entities = new List<LogEntity>(_cloudTable.ExecuteQuery(query));
-                if (expectedCount == entities.Count)
+                var newCount = entities.Count;
+
+                if (newCount == expectedCount || newCount == previousCount)
                 {
                     break;
                 }
+
+                previousCount = newCount;
+                    
             }
 
             return entities;

--- a/NLog.Extensions.AzureTableStorage.Tests/NLog.config
+++ b/NLog.Extensions.AzureTableStorage.Tests/NLog.config
@@ -1,34 +1,41 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <extensions>
-        <add assembly="NLog.Extensions.AzureTableStorage"/>
-    </extensions>
-    <targets>
-        <target name="AzureTableStorageKeysTests"
-            xsi:type="AzureTableStorage"
-            PartitionKey="Test.${logger}"
-            RowKey="${ticks}__${guid}"
-            ConnectionString="UseDevelopmentStorage=true"
-            tableName="AzureTableStorageKeysTests" />
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" throwExceptions="true">
+  <extensions>
+    <add assembly="NLog.Extensions.AzureTableStorage" />
+  </extensions>
+  <targets>
+    <target name="AzureTableStorageKeysTests"
+        xsi:type="AzureTableStorage"
+        PartitionKey="Test.${logger}"
+        RowKey="${ticks}__${guid}"
+        ConnectionString="UseDevelopmentStorage=true"
+        tableName="AzureTableStorageKeysTests" />
 
-        <target name="AzureTableStoragePerformanceTests"
-            xsi:type="AzureTableStorage"
-            PartitionKey="Test.${logger}"
-            RowKey="${ticks}__${guid}"
-            ConnectionString="UseDevelopmentStorage=true"
-            tableName="AzureTableStoragePerformanceTests" />
+    <target xsi:type="AsyncWrapper"
+      name="AzureTableStoragePerformanceTestsAsync"
+      queueLimit="2000"
+      timeToSleepBetweenBatches="0"
+      batchSize="200"
+      overflowAction="Grow">
+      <target name="AzureTableStoragePerformanceTests"
+          xsi:type="AzureTableStorage"
+          PartitionKey="Test.${logger}"
+          RowKey="${ticks}__${guid}"
+          ConnectionString="UseDevelopmentStorage=true"
+          tableName="AzureTableStoragePerformanceTests" />
+    </target>
 
-        <target name="AzureTableStorageTargetTests"
-            xsi:type="AzureTableStorage"
-            PartitionKey="Test.${logger}"
-            RowKey="${ticks}__${guid}"
-            ConnectionString="UseDevelopmentStorage=true"
-            tableName="AzureTableStorageTargetTests" />
-    </targets>
-    <rules>
-        <logger name="AzureTableStorageKeysTests" minlevel="Trace" writeTo="AzureTableStorageKeysTests" />
-        <logger name="AzureTableStoragePerformanceTests" minlevel="Trace" writeTo="AzureTableStoragePerformanceTests" />
-        <logger name="AzureTableStorageTargetTests" minlevel="Trace" writeTo="AzureTableStorageTargetTests" />
-    </rules>
+    <target name="AzureTableStorageTargetTests"
+        xsi:type="AzureTableStorage"
+        PartitionKey="Test.${logger}"
+        RowKey="${ticks}__${guid}"
+        ConnectionString="UseDevelopmentStorage=true"
+        tableName="AzureTableStorageTargetTests" />
+  </targets>
+  <rules>
+    <logger name="AzureTableStorageKeysTests" minlevel="Trace" writeTo="AzureTableStorageKeysTests" />
+    <logger name="AzureTableStoragePerformanceTests" minlevel="Trace" writeTo="AzureTableStoragePerformanceTestsAsync" />
+    <logger name="AzureTableStorageTargetTests" minlevel="Trace" writeTo="AzureTableStorageTargetTests" />
+  </rules>
 </nlog>

--- a/NLog.Extensions.AzureTableStorage/AzureTableStorageTarget.cs
+++ b/NLog.Extensions.AzureTableStorage/AzureTableStorageTarget.cs
@@ -12,7 +12,7 @@ namespace NLog.Extensions.AzureTableStorage
     /// This class represents a target in the NLog.config file.
     /// </summary>
     [Target("AzureTableStorage")]
-    public class AzureTableStorageTarget : TargetWithLayout
+    public class AzureTableStorageTarget : AsyncTaskTarget
     {
         #region Constants
         #endregion Constants
@@ -75,7 +75,7 @@ namespace NLog.Extensions.AzureTableStorage
             WriteAsyncTask(logEvent, new CancellationToken()).ConfigureAwait(false);
         }
 
-        protected async Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
+        protected override async Task WriteAsyncTask(LogEventInfo logEvent, CancellationToken cancellationToken)
         {
             try
             {

--- a/NLog.Extensions.AzureTableStorage/LogEntity.cs
+++ b/NLog.Extensions.AzureTableStorage/LogEntity.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net.NetworkInformation;
 using System.Text;
 using Microsoft.WindowsAzure.Storage.Table;
+using NLog.Layouts;
 
 namespace NLog.Extensions.AzureTableStorage
 {
@@ -86,39 +87,7 @@ namespace NLog.Extensions.AzureTableStorage
         #region Methods
         private string TransformKey(string key, LogEventInfo logEvent)
         {
-            var capacity = key.Length * 3;  // Guesstimate of a reasonable maximum length after transform
-            var builder = new StringBuilder(key, capacity);
-
-            var date = logEvent.TimeStamp.ToUniversalTime();
-            if (InvariantCompareInfo.IndexOf(key, "${date}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${date}", date.ToString("yyyyMMdd"));
-            if (InvariantCompareInfo.IndexOf(key, "${time}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${time}", date.ToString("HHmmss"));
-            if (InvariantCompareInfo.IndexOf(key, "${ticks}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${ticks}", date.Ticks.ToString("d19"));
-            if (InvariantCompareInfo.IndexOf(key, "${longdate}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${longdate}", date.ToString("yyyyMMddHHmmssffffff"));
-            if (InvariantCompareInfo.IndexOf(key, "${micros}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${micros}", date.ToString("ffffff"));
-            if (InvariantCompareInfo.IndexOf(key, "${descticks}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${descticks}", (DateTime.MaxValue.Ticks - date.Ticks).ToString("d19"));
-
-            if (InvariantCompareInfo.IndexOf(key, "${guid}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${guid}", Guid.NewGuid().ToString("N"));
-            if (InvariantCompareInfo.IndexOf(key, "${logger}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${logger}", logEvent.LoggerName);
-
-            var level = logEvent.Level.Name;
-            if (InvariantCompareInfo.IndexOf(key, "${level}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${level}", level);
-            if (InvariantCompareInfo.IndexOf(key, "${level:uppercase=true}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${level:uppercase=true}", level.ToUpper());
-
-            if (InvariantCompareInfo.IndexOf(key, "${machine}", CompareOptions.Ordinal) >= 0)
-                builder.Replace("${machine}", MachineName);
-
-            var result = builder.ToString();
-            return result;
+            return SimpleLayout.Evaluate(key, logEvent).Replace("/", "-");
         }
 
         private static string GetExceptionDataAsString(Exception exception)

--- a/NLog.Extensions.AzureTableStorage/TableStorageManager.cs
+++ b/NLog.Extensions.AzureTableStorage/TableStorageManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using NLog.Common;
@@ -37,7 +38,7 @@ namespace NLog.Extensions.AzureTableStorage
         #endregion Constructors
 
         #region Methods
-        public void EnsureConfigurationIsCurrent(string connectionString, string tableName)
+        public async Task EnsureConfigurationIsCurrentAsync(string connectionString, string tableName)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
                 return;
@@ -60,11 +61,11 @@ namespace NLog.Extensions.AzureTableStorage
             { 
                 // re-initialize the storage manager. the target will now log to the newly specified
                 // storage account and table
-                Initialize(connectionString, tableName);
+                await InitializeAsync(connectionString, tableName);
             }
         }
 
-        private void Initialize(string connectionString, string tableName)
+        private async Task InitializeAsync(string connectionString, string tableName)
         {
             _connectionString = connectionString;
             _tableName = tableName;
@@ -93,7 +94,7 @@ namespace NLog.Extensions.AzureTableStorage
 
                 //create charts table if not exists.
                 _cloudTable = tableClient.GetTableReference(tableName);
-	            _cloudTable.CreateIfNotExistsAsync();
+                await _cloudTable.CreateIfNotExistsAsync();
             }
             catch (Exception exception)
             {
@@ -115,7 +116,7 @@ namespace NLog.Extensions.AzureTableStorage
         /// Check if the connection has been initialized properly (_cloudTable is not null).
         /// </summary>
         /// <param name="entity"></param>
-        public void Add(LogEntity entity)
+        public async Task AddAsync(LogEntity entity)
         {
             // check if this connection has been initialized. if it hasn't, it is likely because
             // we were unable to connect, or the config is invalid, or the "development storage" is used 
@@ -131,7 +132,7 @@ namespace NLog.Extensions.AzureTableStorage
             }
 
             var insertOperation = TableOperation.Insert(entity);
-            _cloudTable.ExecuteAsync(insertOperation);
+            await _cloudTable.ExecuteAsync(insertOperation);
         }
     }
     #endregion Methods


### PR DESCRIPTION
Was there a reason why it was chosen to not use the SimpleLayout to render the two keys? The code I'm proposing allows this as a partition key, which I think makes a lot of sense in an ASP.Net context: 

PartitionKey="${date:universalTime=true:format=yyyyMMdd}.${when:when=length('${aspnet-TraceIdentifier}')>0:inner=${aspnet-TraceIdentifier}:else=ServerLogging"

Also, I've changed all async calls to actually use Async/Await, and made the Target in to an Async, and updated the tests. 

The tests become a bit more difficult because of Nlog's Fire and forget async handling, so I added some sleeps in there to ensure the results are good.